### PR TITLE
Adds txdb support for bindvars

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -21,7 +21,7 @@ const (
 // BindType returns the bindtype for a given database given a drivername.
 func BindType(driverName string) int {
 	switch driverName {
-	case "postgres", "pgx":
+	case "postgres", "pgx", "txdb": // Reverb: Adds txdb support for bindvars -- if you're using something other than postgres, you'll want to change this.
 		return DOLLAR
 	case "mysql":
 		return QUESTION


### PR DESCRIPTION
  * We use sqlx in a number of projects _and_ we use txdb in a number
    of projects. txdb does a great job of cleaning the db, but because
    it obscures the original driver sqlx does not know what kind of
    bindvar it should use for named queries.
  * Named Queries:
      * http://jmoiron.github.io/sqlx/#namedParams
      * https://godoc.org/github.com/jmoiron/sqlx#NamedExec
  * https://github.com/DATA-DOG/go-txdb